### PR TITLE
Add play/pause functionality using orchestrator pattern

### DIFF
--- a/components/complex-exercise/lib/Orchestrator.ts
+++ b/components/complex-exercise/lib/Orchestrator.ts
@@ -113,12 +113,17 @@ class Orchestrator {
     this.store.getState().setExerciseTitle(title);
   }
 
-  setCurrentTestTime(time: number) {
-    this.timelineManager.setTime(time);
-  }
-
   setCurrentTest(test: TestResult | null) {
     this.store.getState().setCurrentTest(test);
+  }
+
+  /*
+    This method is specifically for when we want to set a specific time.
+    It's not for side-effects (e.g. when the animation is playing and we
+    are syncing the time).
+  */
+  setCurrentTestTime(time: number) {
+    this.timelineManager.setTime(time);
   }
 
   setFoldedLines(lines: number[]) {
@@ -187,6 +192,44 @@ class Orchestrator {
 
   setShouldAutoplayAnimation(autoplay: boolean) {
     this.store.getState().setShouldAutoplayAnimation(autoplay);
+  }
+
+  // Play/pause methods
+  play() {
+    const state = this.store.getState();
+    if (!state.currentTest) {
+      return;
+    }
+
+    // Set isPlaying state
+    state.setIsPlaying(true);
+
+    // Hide information widget on play (matches original behavior)
+    state.setShouldShowInformationWidget(false);
+
+    // Play the animation timeline
+    state.currentTest.animationTimeline.play();
+  }
+
+  pause() {
+    const state = this.store.getState();
+    if (!state.currentTest) {
+      return;
+    }
+
+    // Set isPlaying state
+    state.setIsPlaying(false);
+
+    // Pause the animation timeline
+    state.currentTest.animationTimeline.pause();
+
+    // Snap to nearest frame after pausing
+    this.snapToNearestFrame();
+  }
+
+  // Snap to the nearest frame - delegate to TimelineManager
+  snapToNearestFrame() {
+    this.timelineManager.snapToNearestFrame();
   }
 
   // Error store public methods

--- a/components/complex-exercise/lib/orchestrator/TimelineManager.ts
+++ b/components/complex-exercise/lib/orchestrator/TimelineManager.ts
@@ -1,5 +1,4 @@
 import type { Frame } from "interpreters";
-import { TIME_SCALE_FACTOR } from "interpreters";
 import type { StoreApi } from "zustand/vanilla";
 import type { OrchestratorState } from "../types";
 
@@ -176,10 +175,9 @@ export class TimelineManager {
     state.setCurrentTestTime(time);
 
     // Also seek the animation timeline if it exists
-    // Convert microseconds to milliseconds for AnimeJS
     const animationTimeline = state.currentTest?.animationTimeline;
     if (animationTimeline) {
-      animationTimeline.seek(Math.round(time / TIME_SCALE_FACTOR));
+      animationTimeline.seek(time);
     }
   }
 
@@ -195,6 +193,20 @@ export class TimelineManager {
     }
 
     return TimelineManager.findNearestFrame(state.currentTest?.frames, time, state.foldedLines);
+  }
+
+  /**
+   * Snaps to the nearest frame - used by pause and ScrubberInput mouseUp.
+   * Finds the nearest frame and sets the timeline to that position.
+   */
+  snapToNearestFrame(): void {
+    const nearestFrame = this.getNearestCurrentFrame();
+    if (!nearestFrame) {
+      return;
+    }
+
+    // Snap to the nearest frame's timeline position
+    this.setTime(nearestFrame.time);
   }
 
   /**

--- a/components/complex-exercise/lib/test-runner/runTests.ts
+++ b/components/complex-exercise/lib/test-runner/runTests.ts
@@ -46,7 +46,7 @@ function runScenario(scenario: Scenario, studentCode: string): TestResult {
   const frames = result.frames;
 
   // Always create animation timeline (required for scrubber)
-  const animationTimeline = new AnimationTimelineClass({}, frames).populateTimeline(exercise.animations, false);
+  const animationTimeline = new AnimationTimelineClass({}).populateTimeline(exercise.animations, frames);
 
   // Animation timeline is ready for scrubber
 

--- a/components/complex-exercise/lib/types.ts
+++ b/components/complex-exercise/lib/types.ts
@@ -62,6 +62,9 @@ export interface OrchestratorState {
 
   // Current frame - extracted from currentTest to prevent rerenders
   currentFrame: Frame | undefined;
+
+  // Play/pause state for animation timeline
+  isPlaying: boolean;
 }
 
 // Private actions only accessible within the orchestrator
@@ -98,6 +101,9 @@ export interface OrchestratorActions {
 
   // Test results actions
   setTestSuiteResult: (result: TestSuiteResult | null) => void;
+
+  // Play/pause action
+  setIsPlaying: (playing: boolean) => void;
   setShouldAutoplayAnimation: (autoplay: boolean) => void;
 
   // Exercise data initialization

--- a/components/complex-exercise/ui/scrubber/PlayPauseButton.tsx
+++ b/components/complex-exercise/ui/scrubber/PlayPauseButton.tsx
@@ -1,0 +1,36 @@
+import { useOrchestratorStore } from "../../lib/Orchestrator";
+import { useOrchestrator } from "../../lib/OrchestratorContext";
+
+interface PlayPauseButtonProps {
+  disabled: boolean;
+}
+
+export default function PlayPauseButton({ disabled }: PlayPauseButtonProps) {
+  const orchestrator = useOrchestrator();
+  const { isPlaying, currentTest } = useOrchestratorStore(orchestrator);
+
+  // Don't show button if there's no animation timeline
+  const animationTimeline = currentTest?.animationTimeline;
+  if (!animationTimeline) {
+    return null;
+  }
+
+  const handleClick = () => {
+    if (isPlaying) {
+      orchestrator.pause();
+    } else {
+      orchestrator.play();
+    }
+  };
+
+  return (
+    <button
+      data-ci={isPlaying ? "pause-button" : "play-button"}
+      disabled={disabled}
+      className="play-pause-button"
+      onClick={handleClick}
+    >
+      <span style={{ fontSize: "32px", lineHeight: 1 }}>{isPlaying ? "⏸️" : "▶️"}</span>
+    </button>
+  );
+}

--- a/components/complex-exercise/ui/scrubber/Scrubber.tsx
+++ b/components/complex-exercise/ui/scrubber/Scrubber.tsx
@@ -4,6 +4,7 @@ import { useOrchestrator } from "../../lib/OrchestratorContext";
 import ScrubberInput from "./ScrubberInput";
 import FrameStepperButtons from "./FrameStepperButtons";
 import BreakpointStepperButtons from "./BreakpointStepperButtons";
+import PlayPauseButton from "./PlayPauseButton";
 
 export default function Scrubber() {
   const orchestrator = useOrchestrator();
@@ -27,16 +28,7 @@ export default function Scrubber() {
       tabIndex={-1}
       className="relative group flex-1"
     >
-      {/* <PlayPauseButton
-        animationTimeline={animationTimeline}
-        enabled={isEnabled}
-        onPlay={() => {
-          animationTimeline.play(() => setShouldShowInformationWidget(false))
-        }}
-        onPause={() => {
-          animationTimeline.pause()
-        }}
-      /> */}
+      <PlayPauseButton disabled={!isEnabled} />
       <ScrubberInput
         ref={rangeRef}
         frames={frames}

--- a/components/complex-exercise/ui/scrubber/ScrubberInput.tsx
+++ b/components/complex-exercise/ui/scrubber/ScrubberInput.tsx
@@ -67,13 +67,7 @@ function handleOnKeyDown(
 // But when they let go of the mouse we need to lock onto a frame. So this
 // does that. It grabs the nearest frame to the current scrub and moves to it.
 function handleOnMouseUp(orchestrator: ReturnType<typeof useOrchestrator>) {
-  const nearestFrame = orchestrator.getNearestCurrentFrame();
-  if (!nearestFrame) {
-    return;
-  }
-
-  // Snap to the nearest frame's timeline position
-  orchestrator.setCurrentTestTime(nearestFrame.time);
+  orchestrator.snapToNearestFrame();
 }
 
 function updateInputBackground() {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,12 +82,12 @@ importers:
       react-dom:
         specifier: 19.1.0
         version: 19.1.0(react@19.1.0)
-      react-modal:
-        specifier: ^3.16.3
-        version: 3.16.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react-hot-toast:
         specifier: ^2.6.0
         version: 2.6.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react-modal:
+        specifier: ^3.16.3
+        version: 3.16.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       zustand:
         specifier: ^5.0.8
         version: 5.0.8(@types/react@19.1.13)(react@19.1.0)
@@ -198,6 +198,12 @@ importers:
         specifier: ^2.1.4
         version: 2.1.4
     devDependencies:
+      "@eslint/eslintrc":
+        specifier: ^3.3.1
+        version: 3.3.1
+      "@eslint/js":
+        specifier: ^9.36.0
+        version: 9.36.0
       "@types/didyoumean":
         specifier: ^1.2.3
         version: 1.2.3
@@ -210,9 +216,18 @@ importers:
       "@types/node":
         specifier: ^24.5.2
         version: 24.5.2
+      "@typescript-eslint/eslint-plugin":
+        specifier: ^8.44.1
+        version: 8.44.1(@typescript-eslint/parser@8.44.1(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2))(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2)
+      "@typescript-eslint/parser":
+        specifier: ^8.44.1
+        version: 8.44.1(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2)
       esbuild:
         specifier: ^0.25.10
         version: 0.25.10
+      eslint:
+        specifier: ^9.36.0
+        version: 9.36.0(jiti@2.6.0)
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -7632,7 +7647,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.44.1(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.36.0(jiti@2.6.0)))(eslint@9.36.0(jiti@2.6.0)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.44.1(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.36.0(jiti@2.6.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -7654,7 +7669,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.36.0(jiti@2.6.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.44.1(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.36.0(jiti@2.6.0)))(eslint@9.36.0(jiti@2.6.0))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.44.1(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.36.0(jiti@2.6.0))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/tests/mocks/mockAnimationTimeline.ts
+++ b/tests/mocks/mockAnimationTimeline.ts
@@ -3,8 +3,6 @@ import type { AnimationTimeline } from "@/components/complex-exercise/lib/Animat
 interface MockAnimationTimelineOptions {
   duration?: number; // in microseconds
   paused?: boolean;
-  progress?: number;
-  currentTime?: number;
   completed?: boolean;
   hasPlayedOrScrubbed?: boolean;
 }
@@ -20,8 +18,6 @@ export function mockAnimationTimeline(options: MockAnimationTimelineOptions = {}
   const {
     duration = 1000000, // Default 1 second in microseconds
     paused = true,
-    progress = 0,
-    currentTime = 0,
     completed = false,
     hasPlayedOrScrubbed = false
   } = options;
@@ -34,26 +30,21 @@ export function mockAnimationTimeline(options: MockAnimationTimelineOptions = {}
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const seek = typeof jest !== "undefined" && jest.fn ? jest.fn() : () => {};
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-  const seekEndOfTimeline = typeof jest !== "undefined" && jest.fn ? jest.fn() : () => {};
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const onUpdate = typeof jest !== "undefined" && jest.fn ? jest.fn() : () => {};
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  const clearUpdateCallbacks = typeof jest !== "undefined" && jest.fn ? jest.fn() : () => {};
 
   return {
     pause,
     play,
     paused,
     duration,
-    progress,
-    currentTime,
     completed,
     hasPlayedOrScrubbed,
     seek,
-    seekEndOfTimeline,
     onUpdate,
-    timeline: {
-      duration,
-      currentTime
-    } as any // Timeline is from anime.js, we only need these properties for testing
+    clearUpdateCallbacks,
+    showPlayButton: true
   } as unknown as AnimationTimeline;
 }
 

--- a/tests/mocks/orchestrator-store.ts
+++ b/tests/mocks/orchestrator-store.ts
@@ -56,6 +56,9 @@ export function mockStore(overrides: Partial<OrchestratorStore> = {}) {
       // Current frame
       currentFrame: undefined,
 
+      // Play/pause state
+      isPlaying: false,
+
       // Apply overrides
       ...overrides,
 
@@ -106,6 +109,9 @@ export function mockStore(overrides: Partial<OrchestratorStore> = {}) {
       // Test results actions
       setTestSuiteResult: jest.fn(),
       setShouldAutoplayAnimation: jest.fn(),
+
+      // Play/pause action
+      setIsPlaying: jest.fn(),
 
       // Exercise data initialization
       initializeExerciseData: jest.fn(),

--- a/tests/mocks/orchestrator.ts
+++ b/tests/mocks/orchestrator.ts
@@ -10,6 +10,7 @@ export function mockOrchestrator(): Orchestrator {
     setHasCodeBeenEdited: jest.fn(),
     setIsSpotlightActive: jest.fn(),
     getNearestCurrentFrame: jest.fn().mockReturnValue(null),
+    snapToNearestFrame: jest.fn(),
     runCode: jest.fn(),
     getStore: jest.fn()
   } as unknown as Orchestrator;

--- a/tests/unit/components/complex-exercise/orchestrator/Orchestrator.test.ts
+++ b/tests/unit/components/complex-exercise/orchestrator/Orchestrator.test.ts
@@ -1,6 +1,6 @@
 import Orchestrator, { useOrchestratorStore } from "@/components/complex-exercise/lib/Orchestrator";
 import * as localStorage from "@/components/complex-exercise/lib/localStorage";
-import { mockFrame } from "@/tests/mocks";
+import { mockFrame, mockAnimationTimeline } from "@/tests/mocks";
 import { renderHook } from "@testing-library/react";
 
 // Mock localStorage functions
@@ -90,7 +90,7 @@ describe("Orchestrator", () => {
         expects: [],
         view: document.createElement("div"),
         frames: testFrames,
-        animationTimeline: null as any
+        animationTimeline: mockAnimationTimeline()
       });
 
       const state = orchestrator.getStore().getState();
@@ -128,7 +128,7 @@ describe("Orchestrator", () => {
         expects: [],
         view: document.createElement("div"),
         frames: testFrames,
-        animationTimeline: null as any
+        animationTimeline: mockAnimationTimeline()
       });
 
       // Verify initial state

--- a/tests/unit/components/complex-exercise/orchestrator/TimelineManager.test.ts
+++ b/tests/unit/components/complex-exercise/orchestrator/TimelineManager.test.ts
@@ -206,7 +206,7 @@ describe("TimelineManager", () => {
 
         const state = store.getState() as any;
         expect(state.currentTestTime).toBe(200000);
-        expect(mockSeek).toHaveBeenCalledWith(200); // 200000 / 1000 for microseconds to milliseconds
+        expect(mockSeek).toHaveBeenCalledWith(200000); // Now expects microseconds directly
       });
 
       it("should not seek if no animation timeline exists", () => {

--- a/tests/unit/components/complex-exercise/scrubber/ScrubberInput.test.tsx
+++ b/tests/unit/components/complex-exercise/scrubber/ScrubberInput.test.tsx
@@ -212,9 +212,8 @@ describe("ScrubberInput Component", () => {
     it("should snap to nearest frame on mouse up", () => {
       const mockOrchestrator = createMockOrchestrator();
       const mockTimeline = mockAnimationTimeline({ duration: 10 });
-      const nearestFrame = createMockFrames(5)[2]; // Frame at index 2
 
-      mockOrchestrator.getNearestCurrentFrame = jest.fn().mockReturnValue(nearestFrame);
+      mockOrchestrator.snapToNearestFrame = jest.fn();
 
       render(
         <OrchestratorTestProvider orchestrator={mockOrchestrator}>
@@ -230,15 +229,14 @@ describe("ScrubberInput Component", () => {
       const input = screen.getByRole("slider");
       fireEvent.mouseUp(input);
 
-      expect(mockOrchestrator.getNearestCurrentFrame).toHaveBeenCalled();
-      expect(mockOrchestrator.setCurrentTestTime).toHaveBeenCalledWith(nearestFrame.time);
+      expect(mockOrchestrator.snapToNearestFrame).toHaveBeenCalled();
     });
 
-    it("should not snap if no nearest frame is found", () => {
+    it("should call snapToNearestFrame regardless of frame availability", () => {
       const mockOrchestrator = createMockOrchestrator();
       const mockTimeline = mockAnimationTimeline({ duration: 10 });
 
-      mockOrchestrator.getNearestCurrentFrame = jest.fn().mockReturnValue(null);
+      mockOrchestrator.snapToNearestFrame = jest.fn();
 
       render(
         <OrchestratorTestProvider orchestrator={mockOrchestrator}>
@@ -249,9 +247,8 @@ describe("ScrubberInput Component", () => {
       const input = screen.getByRole("slider");
       fireEvent.mouseUp(input);
 
-      expect(mockOrchestrator.getNearestCurrentFrame).toHaveBeenCalled();
-      // Should not call setCurrentTestTime when no frame is found
-      expect(mockOrchestrator.setCurrentTestTime).not.toHaveBeenCalled();
+      // snapToNearestFrame is always called, it handles the null case internally
+      expect(mockOrchestrator.snapToNearestFrame).toHaveBeenCalled();
     });
   });
 

--- a/tests/unit/components/complex-exercise/test-runner/runTests.test.ts
+++ b/tests/unit/components/complex-exercise/test-runner/runTests.test.ts
@@ -61,9 +61,8 @@ jest.mock("@/components/complex-exercise/lib/mock-exercise/BasicExercise.test", 
 // Mock the AnimationTimeline
 jest.mock("@/components/complex-exercise/lib/AnimationTimeline", () => {
   return {
-    AnimationTimeline: jest.fn().mockImplementation((options, frames) => ({
-      frames,
-      duration: frames[frames.length - 1]?.time || 0,
+    AnimationTimeline: jest.fn().mockImplementation((_options) => ({
+      duration: 0,
       populateTimeline: jest.fn().mockReturnThis()
     }))
   };

--- a/tests/unit/components/complex-exercise/ui/CodeEditor.test.tsx
+++ b/tests/unit/components/complex-exercise/ui/CodeEditor.test.tsx
@@ -76,7 +76,10 @@ describe("CodeEditor", () => {
 
       // Current test time and frame
       currentTestTime: 0,
-      currentFrame: undefined
+      currentFrame: undefined,
+
+      // Play/pause state
+      isPlaying: false
     });
   });
 


### PR DESCRIPTION
## Summary
- Implemented play/pause controls for animation timeline using the orchestrator pattern
- Created new PlayPauseButton component with emoji icons (▶️/⏸️)
- Added timeline synchronization and cleanup when switching between tests

## Key Changes

### Orchestrator State Management
- Added `isPlaying` boolean state to track play/pause status
- Implemented `play()` and `pause()` methods in Orchestrator class
- Added `snapToNearestFrame()` method shared by pause and ScrubberInput mouseUp
- Moved frame snapping logic to TimelineManager for better encapsulation

### Timeline Synchronization
- Added AnimationTimeline callback cleanup when switching tests (`clearUpdateCallbacks()`)
- Set up onUpdate callbacks to sync animation timeline position with store
- Convert between AnimeJS milliseconds and internal microseconds

### Component Updates
- Created PlayPauseButton component using orchestrator pattern
- Updated ScrubberInput to use shared snapToNearestFrame method
- Integrated PlayPauseButton into Scrubber component

### Code Cleanup
- Removed unused AnimationTimeline methods and properties (progress, currentFrame, timeline, etc.)
- Updated all tests to match simplified AnimationTimeline API
- Fixed mock objects to include new methods
- Updated context documentation in `.context/complex-exercise/scrubber-implementation.md`

## Test Plan
- [x] All 497 unit tests passing
- [x] All 116 e2e tests passing
- [x] TypeScript compilation successful
- [x] ESLint clean
- [ ] Manual testing of play/pause functionality
- [ ] Verify frame snapping works correctly on pause
- [ ] Test switching between tests cleans up callbacks properly

🤖 Generated with [Claude Code](https://claude.ai/code)