### PR TITLE
Add /ci comment-triggered workflow to rerun CI tests

### DIFF
--- a/.github/workflows/rerun-ci.yml
+++ b/.github/workflows/rerun-ci.yml
@@ -1,0 +1,181 @@
+name: Rerun CI on Comment
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  actions: write
+  pull-requests: write
+
+jobs:
+  rerun-ci:
+    if: |
+      github.event.issue.pull_request &&
+      (contains(github.event.comment.body, '/ci'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add eyes reaction
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'eyes'
+            });
+
+      - name: Check authorization
+        id: auth_check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const user = context.payload.comment.user.login;
+            try {
+              const { data: collaborator } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: user
+              });
+
+              const hasPermission = ['admin', 'write'].includes(collaborator.permission);
+              core.setOutput('authorized', hasPermission);
+
+              if (!hasPermission) {
+                // Remove eyes reaction and add thumbs down
+                const reactions = await github.rest.reactions.listForIssueComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: context.payload.comment.id
+                });
+
+                const eyesReaction = reactions.data.find(r =>
+                  r.content === 'eyes' && r.user.login === 'github-actions[bot]'
+                );
+
+                if (eyesReaction) {
+                  await github.rest.reactions.deleteForIssueComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    comment_id: context.payload.comment.id,
+                    reaction_id: eyesReaction.id
+                  });
+                }
+
+                await github.rest.reactions.createForIssueComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: context.payload.comment.id,
+                  content: '-1'
+                });
+
+                core.info(`User ${user} is not authorized to trigger CI reruns`);
+              }
+            } catch (error) {
+              core.setFailed(`Error checking permissions: ${error.message}`);
+            }
+
+      - name: Get PR information
+        if: steps.auth_check.outputs.authorized == 'true'
+        id: pr_info
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr_number = context.issue.number;
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr_number
+            });
+
+            core.setOutput('head_sha', pr.head.sha);
+            core.setOutput('head_ref', pr.head.ref);
+            console.log(`PR #${pr_number}: branch=${pr.head.ref}, sha=${pr.head.sha}`);
+
+      - name: Determine rerun mode
+        if: steps.auth_check.outputs.authorized == 'true'
+        id: rerun_mode
+        run: |
+          if [[ "${{ github.event.comment.body }}" == *"/ci all"* ]]; then
+            echo "mode=all" >> $GITHUB_OUTPUT
+          else
+            echo "mode=failed" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Rerun workflows
+        if: steps.auth_check.outputs.authorized == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const mode = '${{ steps.rerun_mode.outputs.mode }}';
+            const head_sha = '${{ steps.pr_info.outputs.head_sha }}';
+
+            // Get all workflow runs for the PR's latest commit
+            const { data: runs } = await github.rest.actions.listWorkflowRunsForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head_sha: head_sha,
+              per_page: 100
+            });
+
+            let rerunCount = 0;
+            const workflowNames = new Set();
+
+            for (const run of runs.workflow_runs) {
+              // Skip the rerun-ci workflow itself
+              if (run.name === 'Rerun CI on Comment') continue;
+
+              // Check if we should rerun this workflow
+              const shouldRerun = mode === 'all' ||
+                                   run.status === 'completed' && run.conclusion === 'failure';
+
+              if (shouldRerun) {
+                try {
+                  await github.rest.actions.reRunWorkflow({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    run_id: run.id
+                  });
+                  rerunCount++;
+                  workflowNames.add(run.name);
+                  console.log(`Rerunning: ${run.name} (${run.id})`);
+                } catch (error) {
+                  console.log(`Failed to rerun ${run.name}: ${error.message}`);
+                }
+              }
+            }
+
+            // Update reaction to thumbs up
+            const reactions = await github.rest.reactions.listForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id
+            });
+
+            const eyesReaction = reactions.data.find(r =>
+              r.content === 'eyes' && r.user.login === 'github-actions[bot]'
+            );
+
+            if (eyesReaction) {
+              await github.rest.reactions.deleteForIssueComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: context.payload.comment.id,
+                reaction_id: eyesReaction.id
+              });
+            }
+
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: '+1'
+            });
+
+            if (rerunCount > 0) {
+              console.log(`Successfully triggered ${rerunCount} workflow rerun(s): ${Array.from(workflowNames).join(', ')}`);
+            } else {
+              console.log('No workflows needed to be rerun');
+            }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,18 +204,27 @@ importers:
       "@typescript-eslint/parser":
         specifier: ^8.44.0
         version: 8.44.1(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2)
+      "@vitest/ui":
+        specifier: ^3.2.4
+        version: 3.2.4(vitest@3.2.4)
       eslint:
         specifier: ^9
         version: 9.36.0(jiti@2.6.0)
       husky:
         specifier: ^9.1.7
         version: 9.1.7
+      jsdom:
+        specifier: ^27.0.0
+        version: 27.0.0(postcss@8.5.6)
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
       typescript:
         specifier: ^5
         version: 5.9.2
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@20.19.17)(@vitest/ui@3.2.4)(jiti@2.6.0)(jsdom@27.0.0(postcss@8.5.6))(lightningcss@1.30.1)
 
   ../interpreters:
     dependencies:
@@ -279,7 +288,7 @@ importers:
         version: 5.9.2
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@24.5.2)(jiti@2.6.0)(jsdom@26.1.0)(lightningcss@1.30.1)
+        version: 3.2.4(@types/node@24.5.2)(@vitest/ui@3.2.4)(jiti@2.6.0)(jsdom@27.0.0(postcss@8.5.6))(lightningcss@1.30.1)
 
 packages:
   "@adobe/css-tools@4.4.4":
@@ -294,6 +303,18 @@ packages:
   "@asamuzakjp/css-color@3.2.0":
     resolution:
       { integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw== }
+
+  "@asamuzakjp/css-color@4.0.5":
+    resolution:
+      { integrity: sha512-lMrXidNhPGsDjytDy11Vwlb6OIGrT3CmLg3VWNFyWkLWtijKl7xjvForlh8vuj0SHGjgl4qZEQzUmYTeQA2JFQ== }
+
+  "@asamuzakjp/dom-selector@6.5.6":
+    resolution:
+      { integrity: sha512-Mj3Hu9ymlsERd7WOsUKNUZnJYL4IZ/I9wVVYgtvOsWYiEFbkQ4G7VRIh2USxTVW4BBDIsLG+gBUgqOqf2Kvqow== }
+
+  "@asamuzakjp/nwsapi@2.3.9":
+    resolution:
+      { integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q== }
 
   "@babel/code-frame@7.27.1":
     resolution:
@@ -559,6 +580,13 @@ packages:
     engines: { node: ">=18" }
     peerDependencies:
       "@csstools/css-tokenizer": ^3.0.4
+
+  "@csstools/css-syntax-patches-for-csstree@1.0.14":
+    resolution:
+      { integrity: sha512-zSlIxa20WvMojjpCSy8WrNpcZ61RqfTfX3XTaOeVlGJrt/8HF3YbzgFZa01yTbT4GWQLwfTcC3EB8i3XnB647Q== }
+    engines: { node: ">=18" }
+    peerDependencies:
+      postcss: ^8.4
 
   "@csstools/css-tokenizer@3.0.4":
     resolution:
@@ -1427,6 +1455,10 @@ packages:
       { integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA== }
     engines: { node: ^12.20.0 || ^14.18.0 || >=16.0.0 }
 
+  "@polka/url@1.0.0-next.29":
+    resolution:
+      { integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww== }
+
   "@puppeteer/browsers@2.10.10":
     resolution:
       { integrity: sha512-3ZG500+ZeLql8rE0hjfhkycJjDj0pI/btEh3L9IkWUYcOrgP0xCNRq3HbtbqOPbvDhFaAWD88pDFtlLv8ns8gA== }
@@ -2093,6 +2125,12 @@ packages:
     resolution:
       { integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw== }
 
+  "@vitest/ui@3.2.4":
+    resolution:
+      { integrity: sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA== }
+    peerDependencies:
+      vitest: 3.2.4
+
   "@vitest/utils@3.2.4":
     resolution:
       { integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA== }
@@ -2358,6 +2396,10 @@ packages:
       { integrity: sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg== }
     engines: { node: ">=10.0.0" }
 
+  bidi-js@1.0.3:
+    resolution:
+      { integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw== }
+
   brace-expansion@1.1.12:
     resolution:
       { integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg== }
@@ -2555,6 +2597,11 @@ packages:
       { integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA== }
     engines: { node: ">= 8" }
 
+  css-tree@3.1.0:
+    resolution:
+      { integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w== }
+    engines: { node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0 }
+
   css.escape@1.5.1:
     resolution:
       { integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg== }
@@ -2563,6 +2610,11 @@ packages:
     resolution:
       { integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg== }
     engines: { node: ">=18" }
+
+  cssstyle@5.3.1:
+    resolution:
+      { integrity: sha512-g5PC9Aiph9eiczFpcgUhd9S4UUO3F+LHGRIi5NUMZ+4xtoIYbHNZwZnWA2JsFGe8OU8nl4WyaEFiZuGuxlutJQ== }
+    engines: { node: ">=20" }
 
   csstype@3.1.3:
     resolution:
@@ -2586,6 +2638,11 @@ packages:
     resolution:
       { integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg== }
     engines: { node: ">=18" }
+
+  data-urls@6.0.0:
+    resolution:
+      { integrity: sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA== }
+    engines: { node: ">=20" }
 
   data-view-buffer@1.0.2:
     resolution:
@@ -3067,6 +3124,10 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.8.2:
+    resolution:
+      { integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A== }
 
   file-entry-cache@8.0.0:
     resolution:
@@ -3864,6 +3925,16 @@ packages:
       canvas:
         optional: true
 
+  jsdom@27.0.0:
+    resolution:
+      { integrity: sha512-lIHeR1qlIRrIN5VMccd8tI2Sgw6ieYXSVktcSHaNe3Z5nE/tcPQYQWOq00wxMvYOsz+73eAkNenVvmPC6bba9A== }
+    engines: { node: ">=20" }
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
   jsesc@3.1.0:
     resolution:
       { integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA== }
@@ -4062,6 +4133,11 @@ packages:
     resolution:
       { integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ== }
 
+  lru-cache@11.2.2:
+    resolution:
+      { integrity: sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg== }
+    engines: { node: 20 || >=22 }
+
   lru-cache@5.1.1:
     resolution:
       { integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w== }
@@ -4109,6 +4185,10 @@ packages:
     resolution:
       { integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g== }
     engines: { node: ">= 0.4" }
+
+  mdn-data@2.12.2:
+    resolution:
+      { integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA== }
 
   merge-stream@2.0.0:
     resolution:
@@ -4170,6 +4250,11 @@ packages:
   mitt@3.0.1:
     resolution:
       { integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw== }
+
+  mrmime@2.0.1:
+    resolution:
+      { integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ== }
+    engines: { node: ">=10" }
 
   ms@2.1.3:
     resolution:
@@ -4594,6 +4679,11 @@ packages:
       { integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q== }
     engines: { node: ">=0.10.0" }
 
+  require-from-string@2.0.2:
+    resolution:
+      { integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw== }
+    engines: { node: ">=0.10.0" }
+
   resolve-cwd@3.0.0:
     resolution:
       { integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg== }
@@ -4753,6 +4843,11 @@ packages:
     resolution:
       { integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw== }
     engines: { node: ">=14" }
+
+  sirv@3.0.2:
+    resolution:
+      { integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g== }
+    engines: { node: ">=18" }
 
   sisteransi@1.0.5:
     resolution:
@@ -5029,9 +5124,18 @@ packages:
     resolution:
       { integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA== }
 
+  tldts-core@7.0.16:
+    resolution:
+      { integrity: sha512-XHhPmHxphLi+LGbH0G/O7dmUH9V65OY20R7vH8gETHsp5AZCjBk9l8sqmRKLaGOxnETU7XNSDUPtewAy/K6jbA== }
+
   tldts@6.1.86:
     resolution:
       { integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ== }
+    hasBin: true
+
+  tldts@7.0.16:
+    resolution:
+      { integrity: sha512-5bdPHSwbKTeHmXrgecID4Ljff8rQjv7g8zKQPkCozRo2HWWni+p310FSn5ImI+9kWw9kK4lzOB5q/a6iv0IJsw== }
     hasBin: true
 
   tmpl@1.0.5:
@@ -5043,15 +5147,30 @@ packages:
       { integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ== }
     engines: { node: ">=8.0" }
 
+  totalist@3.0.1:
+    resolution:
+      { integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ== }
+    engines: { node: ">=6" }
+
   tough-cookie@5.1.2:
     resolution:
       { integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A== }
+    engines: { node: ">=16" }
+
+  tough-cookie@6.0.0:
+    resolution:
+      { integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w== }
     engines: { node: ">=16" }
 
   tr46@5.1.1:
     resolution:
       { integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw== }
     engines: { node: ">=18" }
+
+  tr46@6.0.0:
+    resolution:
+      { integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw== }
+    engines: { node: ">=20" }
 
   tree-kill@1.2.2:
     resolution:
@@ -5309,6 +5428,11 @@ packages:
       { integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g== }
     engines: { node: ">=12" }
 
+  webidl-conversions@8.0.0:
+    resolution:
+      { integrity: sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA== }
+    engines: { node: ">=20" }
+
   whatwg-encoding@3.1.1:
     resolution:
       { integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ== }
@@ -5323,6 +5447,11 @@ packages:
     resolution:
       { integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw== }
     engines: { node: ">=18" }
+
+  whatwg-url@15.1.0:
+    resolution:
+      { integrity: sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g== }
+    engines: { node: ">=20" }
 
   which-boxed-primitive@1.1.1:
     resolution:
@@ -5486,6 +5615,24 @@ snapshots:
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
       lru-cache: 10.4.3
+
+  "@asamuzakjp/css-color@4.0.5":
+    dependencies:
+      "@csstools/css-calc": 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      "@csstools/css-color-parser": 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
+      "@csstools/css-tokenizer": 3.0.4
+      lru-cache: 11.2.2
+
+  "@asamuzakjp/dom-selector@6.5.6":
+    dependencies:
+      "@asamuzakjp/nwsapi": 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.1.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.2.2
+
+  "@asamuzakjp/nwsapi@2.3.9": {}
 
   "@babel/code-frame@7.27.1":
     dependencies:
@@ -5751,6 +5898,10 @@ snapshots:
   "@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)":
     dependencies:
       "@csstools/css-tokenizer": 3.0.4
+
+  "@csstools/css-syntax-patches-for-csstree@1.0.14(postcss@8.5.6)":
+    dependencies:
+      postcss: 8.5.6
 
   "@csstools/css-tokenizer@3.0.4": {}
 
@@ -6424,6 +6575,8 @@ snapshots:
 
   "@pkgr/core@0.2.9": {}
 
+  "@polka/url@1.0.0-next.29": {}
+
   "@puppeteer/browsers@2.10.10":
     dependencies:
       debug: 4.4.3
@@ -6923,6 +7076,14 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
+  "@vitest/mocker@3.2.4(vite@7.1.7(@types/node@20.19.17)(jiti@2.6.0)(lightningcss@1.30.1))":
+    dependencies:
+      "@vitest/spy": 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.19
+    optionalDependencies:
+      vite: 7.1.7(@types/node@20.19.17)(jiti@2.6.0)(lightningcss@1.30.1)
+
   "@vitest/mocker@3.2.4(vite@7.1.7(@types/node@24.5.2)(jiti@2.6.0)(lightningcss@1.30.1))":
     dependencies:
       "@vitest/spy": 3.2.4
@@ -6950,6 +7111,17 @@ snapshots:
   "@vitest/spy@3.2.4":
     dependencies:
       tinyspy: 4.0.4
+
+  "@vitest/ui@3.2.4(vitest@3.2.4)":
+    dependencies:
+      "@vitest/utils": 3.2.4
+      fflate: 0.8.2
+      flatted: 3.3.3
+      pathe: 2.0.3
+      sirv: 3.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 2.0.0
+      vitest: 3.2.4(@types/node@20.19.17)(@vitest/ui@3.2.4)(jiti@2.6.0)(jsdom@27.0.0(postcss@8.5.6))(lightningcss@1.30.1)
 
   "@vitest/utils@3.2.4":
     dependencies:
@@ -7208,6 +7380,10 @@ snapshots:
 
   basic-ftp@5.0.5: {}
 
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
   brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
@@ -7363,12 +7539,25 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.1.0:
+    dependencies:
+      mdn-data: 2.12.2
+      source-map-js: 1.2.1
+
   css.escape@1.5.1: {}
 
   cssstyle@4.6.0:
     dependencies:
       "@asamuzakjp/css-color": 3.2.0
       rrweb-cssom: 0.8.0
+
+  cssstyle@5.3.1(postcss@8.5.6):
+    dependencies:
+      "@asamuzakjp/css-color": 4.0.5
+      "@csstools/css-syntax-patches-for-csstree": 1.0.14(postcss@8.5.6)
+      css-tree: 3.1.0
+    transitivePeerDependencies:
+      - postcss
 
   csstype@3.1.3: {}
 
@@ -7385,6 +7574,11 @@ snapshots:
     dependencies:
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
+
+  data-urls@6.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 15.1.0
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -7934,6 +8128,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fflate@0.8.2: {}
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -8875,6 +9071,34 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  jsdom@27.0.0(postcss@8.5.6):
+    dependencies:
+      "@asamuzakjp/dom-selector": 6.5.6
+      cssstyle: 5.3.1(postcss@8.5.6)
+      data-urls: 6.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      parse5: 7.3.0
+      rrweb-cssom: 0.8.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 15.1.0
+      ws: 8.18.3
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - postcss
+      - supports-color
+      - utf-8-validate
+
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
@@ -9008,6 +9232,8 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
+  lru-cache@11.2.2: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -9037,6 +9263,8 @@ snapshots:
   marked@16.3.0: {}
 
   math-intrinsics@1.1.0: {}
+
+  mdn-data@2.12.2: {}
 
   merge-stream@2.0.0: {}
 
@@ -9074,6 +9302,8 @@ snapshots:
       minipass: 7.1.2
 
   mitt@3.0.1: {}
+
+  mrmime@2.0.1: {}
 
   ms@2.1.3: {}
 
@@ -9469,6 +9699,8 @@ snapshots:
 
   require-directory@2.1.1: {}
 
+  require-from-string@2.0.2: {}
+
   resolve-cwd@3.0.0:
     dependencies:
       resolve-from: 5.0.0
@@ -9658,6 +9890,12 @@ snapshots:
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
+
+  sirv@3.0.2:
+    dependencies:
+      "@polka/url": 1.0.0-next.29
+      mrmime: 2.0.1
+      totalist: 3.0.1
 
   sisteransi@1.0.5: {}
 
@@ -9899,9 +10137,15 @@ snapshots:
 
   tldts-core@6.1.86: {}
 
+  tldts-core@7.0.16: {}
+
   tldts@6.1.86:
     dependencies:
       tldts-core: 6.1.86
+
+  tldts@7.0.16:
+    dependencies:
+      tldts-core: 7.0.16
 
   tmpl@1.0.5: {}
 
@@ -9909,11 +10153,21 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  totalist@3.0.1: {}
+
   tough-cookie@5.1.2:
     dependencies:
       tldts: 6.1.86
 
+  tough-cookie@6.0.0:
+    dependencies:
+      tldts: 7.0.16
+
   tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
+
+  tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
 
@@ -10053,6 +10307,27 @@ snapshots:
       "@types/istanbul-lib-coverage": 2.0.6
       convert-source-map: 2.0.0
 
+  vite-node@3.2.4(@types/node@20.19.17)(jiti@2.6.0)(lightningcss@1.30.1):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.1.7(@types/node@20.19.17)(jiti@2.6.0)(lightningcss@1.30.1)
+    transitivePeerDependencies:
+      - "@types/node"
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite-node@3.2.4(@types/node@24.5.2)(jiti@2.6.0)(lightningcss@1.30.1):
     dependencies:
       cac: 6.7.14
@@ -10074,6 +10349,20 @@ snapshots:
       - tsx
       - yaml
 
+  vite@7.1.7(@types/node@20.19.17)(jiti@2.6.0)(lightningcss@1.30.1):
+    dependencies:
+      esbuild: 0.25.10
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.52.2
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      "@types/node": 20.19.17
+      fsevents: 2.3.3
+      jiti: 2.6.0
+      lightningcss: 1.30.1
+
   vite@7.1.7(@types/node@24.5.2)(jiti@2.6.0)(lightningcss@1.30.1):
     dependencies:
       esbuild: 0.25.10
@@ -10088,7 +10377,50 @@ snapshots:
       jiti: 2.6.0
       lightningcss: 1.30.1
 
-  vitest@3.2.4(@types/node@24.5.2)(jiti@2.6.0)(jsdom@26.1.0)(lightningcss@1.30.1):
+  vitest@3.2.4(@types/node@20.19.17)(@vitest/ui@3.2.4)(jiti@2.6.0)(jsdom@27.0.0(postcss@8.5.6))(lightningcss@1.30.1):
+    dependencies:
+      "@types/chai": 5.2.2
+      "@vitest/expect": 3.2.4
+      "@vitest/mocker": 3.2.4(vite@7.1.7(@types/node@20.19.17)(jiti@2.6.0)(lightningcss@1.30.1))
+      "@vitest/pretty-format": 3.2.4
+      "@vitest/runner": 3.2.4
+      "@vitest/snapshot": 3.2.4
+      "@vitest/spy": 3.2.4
+      "@vitest/utils": 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.2.2
+      magic-string: 0.30.19
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.1.7(@types/node@20.19.17)(jiti@2.6.0)(lightningcss@1.30.1)
+      vite-node: 3.2.4(@types/node@20.19.17)(jiti@2.6.0)(lightningcss@1.30.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      "@types/node": 20.19.17
+      "@vitest/ui": 3.2.4(vitest@3.2.4)
+      jsdom: 27.0.0(postcss@8.5.6)
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vitest@3.2.4(@types/node@24.5.2)(@vitest/ui@3.2.4)(jiti@2.6.0)(jsdom@27.0.0(postcss@8.5.6))(lightningcss@1.30.1):
     dependencies:
       "@types/chai": 5.2.2
       "@vitest/expect": 3.2.4
@@ -10115,7 +10447,8 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       "@types/node": 24.5.2
-      jsdom: 26.1.0
+      "@vitest/ui": 3.2.4(vitest@3.2.4)
+      jsdom: 27.0.0(postcss@8.5.6)
     transitivePeerDependencies:
       - jiti
       - less
@@ -10170,6 +10503,8 @@ snapshots:
 
   webidl-conversions@7.0.0: {}
 
+  webidl-conversions@8.0.0: {}
+
   whatwg-encoding@3.1.1:
     dependencies:
       iconv-lite: 0.6.3
@@ -10180,6 +10515,11 @@ snapshots:
     dependencies:
       tr46: 5.1.1
       webidl-conversions: 7.0.0
+
+  whatwg-url@15.1.0:
+    dependencies:
+      tr46: 6.0.0
+      webidl-conversions: 8.0.0
 
   which-boxed-primitive@1.1.1:
     dependencies:

--- a/tests/mocks/createTestExercise.ts
+++ b/tests/mocks/createTestExercise.ts
@@ -1,5 +1,5 @@
 import type { ExerciseDefinition } from "@jiki/curriculum";
-import { TestExercise } from "./test-exercise/Exercise";
+import { TestExercise } from "@jiki/curriculum";
 import { tasks, scenarios } from "./test-exercise/scenarios";
 
 /**

--- a/tests/mocks/test-exercise/Exercise.ts
+++ b/tests/mocks/test-exercise/Exercise.ts
@@ -1,2 +1,0 @@
-// Re-export TestExercise from curriculum package
-export { TestExercise } from "@jiki/curriculum";

--- a/tests/mocks/test-exercise/index.ts
+++ b/tests/mocks/test-exercise/index.ts
@@ -1,5 +1,5 @@
 import type { ExerciseDefinition } from "@jiki/curriculum";
-import { TestExercise } from "./Exercise";
+import { TestExercise } from "@jiki/curriculum";
 import { tasks, scenarios } from "./scenarios";
 
 export const testExerciseDefinition: ExerciseDefinition = {

--- a/tests/mocks/test-exercise/scenarios.ts
+++ b/tests/mocks/test-exercise/scenarios.ts
@@ -1,5 +1,5 @@
 import type { Task, Scenario, Exercise } from "@jiki/curriculum";
-import type { TestExercise } from "./Exercise";
+import type { TestExercise } from "@jiki/curriculum";
 
 export const tasks: Task[] = [
   {

--- a/tests/unit/components/complex-exercise/test-runner/runTests.test.ts
+++ b/tests/unit/components/complex-exercise/test-runner/runTests.test.ts
@@ -2,7 +2,7 @@ import { runTests } from "@/components/complex-exercise/lib/test-runner/runTests
 import { jikiscript } from "@jiki/interpreters";
 import { createTestExercise } from "@/tests/mocks/createTestExercise";
 import type { Scenario } from "@jiki/curriculum";
-import { TestExercise } from "@/tests/mocks/test-exercise/Exercise";
+import { TestExercise } from "@jiki/curriculum";
 
 // Mock the interpreters module
 jest.mock("@jiki/interpreters", () => ({
@@ -13,7 +13,7 @@ jest.mock("@jiki/interpreters", () => ({
 }));
 
 // Mock the TestExercise
-jest.mock("@/tests/mocks/test-exercise/Exercise", () => {
+jest.mock("@jiki/curriculum", () => {
   return {
     TestExercise: jest.fn().mockImplementation(() => ({
       position: 100, // This will match the expectation for start-at-0


### PR DESCRIPTION
## Summary
- Added a new GitHub Actions workflow that allows authorized users to rerun CI tests by commenting `/ci` on pull requests
- Provides visual feedback using emoji reactions (👍 for success, 👎 for unauthorized users)
- Supports two modes: `/ci` to rerun only failed workflows, and `/ci all` to rerun all workflows

## Features
- **Security**: Only users with write/admin permissions can trigger reruns
- **Visual Feedback**: 
  - 👀 reaction when processing starts
  - 👍 reaction when successfully triggered  
  - 👎 reaction for unauthorized users (no comment to avoid spam)
- **Smart Rerun Logic**:
  - `/ci` - reruns only failed workflows from the latest commit
  - `/ci all` - forces rerun of all CI workflows
  - Automatically skips rerunning itself to avoid loops

## Test plan
- [ ] Comment `/ci` on this PR to test the workflow
- [ ] Verify that the workflow adds appropriate emoji reactions
- [ ] Confirm that only authorized users can trigger reruns
- [ ] Test both `/ci` and `/ci all` modes